### PR TITLE
Removed default setting of the damping factor (to 1) when a N preconditioner is provided by the user.

### DIFF
--- a/pykrylov/lls/lsmr.py
+++ b/pykrylov/lls/lsmr.py
@@ -193,8 +193,6 @@ class LSMRFramework(KrylovMethod):
 
         if itnlim is None: itnlim = minDim
 
-        if N is not None: damp = 1.0
-
         if show:
             print ' '
             print 'LSMR            Least-squares solution of  Ax = b'


### PR DESCRIPTION
Hi Dominique

I removed the default setting of `damp` in LSMR when a N preconditioner is used.
It now allows the user to specify a `damp` factor other than 1.

